### PR TITLE
Use unique pointers instead of raw pointers for LFO classes.

### DIFF
--- a/include/snd.h
+++ b/include/snd.h
@@ -108,7 +108,7 @@ class Sine {
 
  private:
   fp_t out;
-  LFOBase<fp_t>* phaseDriver;
+  std::unique_ptr<LFOBase<fp_t>> phaseDriver;
 };
 
 template<class fp_t>
@@ -123,7 +123,7 @@ class Parabolic {
 
  private:
   fp_t out;
-  LFOBase<fp_t>* phaseDriver;
+  std::unique_ptr<LFOBase<fp_t>> phaseDriver;
 };
 
 template<class fp_t>
@@ -138,7 +138,7 @@ class Triangle {
 
  private:
   fp_t out;
-  LFOBase<fp_t>* phaseDriver;
+  std::unique_ptr<LFOBase<fp_t>> phaseDriver;
 };
 
 template<class fp_t>
@@ -153,7 +153,7 @@ class Sawtooth {
 
  private:
   fp_t out;
-  LFOBase<fp_t>* phaseDriver;
+  std::unique_ptr<LFOBase<fp_t>> phaseDriver;
 };
 
 template<class fp_t>
@@ -170,7 +170,7 @@ class Square {
  private:
   fp_t out;
   fp_t pulseWidth;
-  LFOBase<fp_t>* phaseDriver;
+  std::unique_ptr<LFOBase<fp_t>> phaseDriver;
 };
 
 }; // !LFO

--- a/include/snd.h
+++ b/include/snd.h
@@ -1,6 +1,8 @@
 #ifndef SND_H_
 #define SND_H_
 
+#include <memory>
+
 namespace snd {
 
 /**


### PR DESCRIPTION
Currently, the `LFOBase` instances these classes store are heap-allocated but never deleted. The use of a raw pointer also [implies non-ownership](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning), but it's clear in this scenario that these classes are supposed to own their instance of LFOBase.

The use of `unique_ptr` allows the deleting of these resources when the class goes out of scope, and also disallows the sharing of the heap-allocated resource. This is appropriate as instances of these classes rely on state stored within their own instance of `phaseDriver`.

